### PR TITLE
Thomas/better windows processes

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -27,6 +27,10 @@ type Process interface {
 	Handle() uintptr
 }
 
+func GetProcess(pid int) Process {
+	return getProcess(pid)
+}
+
 // OpenFromPid opens a process by its pid.
 func OpenFromPid(pid int) (p Process, harderror error, softerrors []error) {
 	// This function is implemented by the OS-specific openFromPid function.

--- a/process/process_info.go
+++ b/process/process_info.go
@@ -1,18 +1,16 @@
 package process
 
-type LinuxProcessInfo struct {
-	Id              int    `json:"id" statusFileKey:"Pid"`
-	Command         string `json:"command" statusFileKey:"Name"`
-	UserId          int    `json:"userId" statusFileKey:"Uid"`
-	UserName        string `json:"userName" statusFileKey:""`
-	GroupId         int    `json:"groupId" statusFileKey:"Gid"`
-	GroupName       string `json:"groupName" statusFileKey:""`
-	ParentProcessId int    `json:"parentProcessId" statusFileKey:"PPid"`
-	Executable      string `json:"executable"`
+type ProcessInfo interface {
+	GetId() int
+	GetCommand() string
+	GetParentProcessId() int
+	GetExecutable() string
 }
 
-func ProcessInfo(pid int) (*LinuxProcessInfo, error) {
-	return processInfo(pid)
+func GetProcessInfo(pid int) (*ProcessInfo, error) {
+	var info ProcessInfo
+	info, err := processInfo(pid)
+	return &info, err
 }
 
 func ProcessExe(pid int) (string, error) {

--- a/process/process_info_windows.go
+++ b/process/process_info_windows.go
@@ -50,7 +50,7 @@ func processInfo(pid int) (windowsProcessInfo, error) {
 }
 
 func processExe(pid int) (string, error) {
-	_, executable, _, err := commandExecutableAndPPId(pid)
+	_, executable, _, _, _, err := commandExecutablePPIdPPIdHandleAndSessionId(pid)
 	return executable, err
 }
 

--- a/process/process_info_windows.go
+++ b/process/process_info_windows.go
@@ -7,11 +7,38 @@ import (
 	"strconv"
 )
 
-func processInfo(pid int) (*LinuxProcessInfo, error) {
-	lpi := &LinuxProcessInfo{}
+type windowsProcessInfo struct {
+	Id              int     `json:"id" statusFileKey:"Pid"`
+	Handle          int     `json:"handle"`
+	Command         string  `json:"command" statusFileKey:"Name"`
+	UserName        string  `json:"userName" statusFileKey:""`
+	ParentProcessId int     `json:"parentProcessId" statusFileKey:"PPid"`
+	Executable      string  `json:"executable"`
+	SessionId       int     `json:"sessionId" statusFileKey:"Sid"`
+}
+
+func (wpi windowsProcessInfo) GetId() int {
+	return wpi.Id
+}
+
+func (wpi windowsProcessInfo) GetCommand() string {
+	return wpi.Command
+}
+
+func (wpi windowsProcessInfo) GetParentProcessId() int {
+	return wpi.ParentProcessId
+}
+
+func (wpi windowsProcessInfo) GetExecutable() string {
+	return wpi.Executable
+}
+
+func processInfo(pid int) (windowsProcessInfo, error) {
+	lpi := windowsProcessInfo{}
 	lpi.Id = pid
 	var err error
-	lpi.Command, lpi.Executable, lpi.ParentProcessId, err = commandExecutableAndPPId(pid)
+	lpi.Command, lpi.Executable, lpi.ParentProcessId, lpi.Handle, lpi.SessionId, err =
+		commandExecutablePPIdPPIdHandleAndSessionId(pid)
 	if err != nil {
 		return lpi, err
 	}
@@ -27,12 +54,13 @@ func processExe(pid int) (string, error) {
 	return executable, err
 }
 
-func commandExecutableAndPPId(pid int) (string, string, int, error) {
+func commandExecutablePPIdPPIdHandleAndSessionId(pid int) (string, string, int, int, int, error) {
 	wmicCommand := exec.Command("wmic", "path", "win32_process", "where", "processid=" +
-		strconv.FormatUint(uint64(pid), 10), "get", "commandline,", "executablepath,", "parentprocessid")
+		strconv.FormatUint(uint64(pid), 10), "get", "commandline,", "executablepath,",
+		"parentprocessid", "handle", "sessionid")
 	wmicOutput, err := wmicCommand.Output()
 	if err != nil {
-		return "", "", 0, err
+		return "", "", 0, 0, 0, err
 	}
 
 	wmicLines := bytes.Split(wmicOutput, []byte("\n"))
@@ -40,36 +68,50 @@ func commandExecutableAndPPId(pid int) (string, string, int, error) {
 	processLine := wmicLines[1]
 
 	charIndex := 0
-	var executableIndex int
-	for ; charIndex < len(headingLine); charIndex++ {
-		if len(headingLine) < charIndex + 14 {
-			return "", "", 0, errors.New("ExecutablePath column missing in WMIC output")
-		}
-		if bytes.Equal(headingLine[charIndex:charIndex + 14], []byte("ExecutablePath")) {
-			executableIndex = charIndex
-			charIndex += 14
-			break
-		}
+	executableIndex, charIndex := findHeading(headingLine, []byte("ExecutablePath"), charIndex)
+	if executableIndex == -1 {
+		return "", "", 0, 0, 0, errors.New("\"ExecutablePath\" not found in heading line.")
 	}
-	var pPIdIndex int
-	for ; charIndex < len(headingLine); charIndex++ {
-		if len(headingLine) < charIndex + 15 {
-			return "", "", 0, errors.New("ParentProcessId column missing in WMIC output")
-		}
-		if bytes.Equal(headingLine[charIndex:charIndex + 15], []byte("ParentProcessId")) {
-			pPIdIndex = charIndex
-			break
-		}
+	pPIdIndex, charIndex := findHeading(headingLine, []byte("ParentProcessId"), charIndex)
+	if pPIdIndex == -1 {
+		return "", "", 0, 0, 0, errors.New("\"ParentProcessId\" not found in heading line.")
+	}
+	handleIndex, charIndex := findHeading(headingLine, []byte("Handle"), charIndex)
+	if handleIndex == -1 {
+		return "", "", 0, 0, 0, errors.New("\"Handle\" not found in heading line.")
+	}
+	sessionIdIndex, charIndex := findHeading(headingLine, []byte("SessionId"), charIndex)
+	if sessionIdIndex == -1 {
+		return "", "", 0, 0, 0, errors.New("\"SessionId\" not found in heading line.")
 	}
 
 	command := string(bytes.TrimSpace(processLine[:executableIndex]))
 	executable := string(bytes.TrimSpace(processLine[executableIndex:pPIdIndex]))
-	pPIdString := string(bytes.TrimSpace(processLine[pPIdIndex:]))
+	pPIdString := string(bytes.TrimSpace(processLine[pPIdIndex:handleIndex]))
 	pPId, err := strconv.ParseInt(pPIdString, 10, 64)
 	if err != nil {
 		pPId = -1
 	}
-	return command, executable, int(pPId), nil
+	handleString := string(bytes.TrimSpace(processLine[handleIndex:sessionIdIndex]))
+	handle, err := strconv.ParseInt(handleString, 10, 64)
+	if err != nil {
+		pPId = -1
+	}
+	sessionIdString := string(bytes.TrimSpace(processLine[sessionIdIndex:]))
+	sessionId, err := strconv.ParseInt(sessionIdString, 10, 64)
+	return command, executable, int(pPId), int(handle), int(sessionId), nil
+}
+
+func findHeading(headingLine []byte, targetHeading []byte, searchStart int) (start int, end int) {
+	for charIndex := searchStart; charIndex < len(headingLine); charIndex++ {
+		if len(headingLine) < charIndex + len(targetHeading) {
+			return -1, -1
+		}
+		if bytes.Equal(headingLine[charIndex:charIndex + len(targetHeading)], targetHeading) {
+			return charIndex, charIndex + len(targetHeading)
+		}
+	}
+	return -1, -1
 }
 
 func userName(pid int) (string, error) {

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -12,13 +12,17 @@ import (
 	"strings"
 )
 
-type LinuxProcess int
+type linuxProcess int
 
-func (p LinuxProcess) Pid() int {
+func getProcess(pid int) linuxProcess {
+	return linuxProcess(pid)
+}
+
+func (p linuxProcess) Pid() int {
 	return int(p)
 }
 
-func (p LinuxProcess) Name() (name string, harderror error, softerrors []error) {
+func (p linuxProcess) Name() (name string, harderror error, softerrors []error) {
 	name, err := ProcessExe(p.Pid())
 
 	if err != nil {
@@ -54,11 +58,11 @@ func (p LinuxProcess) Name() (name string, harderror error, softerrors []error) 
 	return name, err, nil
 }
 
-func (p LinuxProcess) Close() (harderror error, softerrors []error) {
+func (p linuxProcess) Close() (harderror error, softerrors []error) {
 	return nil, nil
 }
 
-func (p LinuxProcess) Handle() uintptr {
+func (p linuxProcess) Handle() uintptr {
 	return uintptr(p)
 }
 
@@ -82,7 +86,7 @@ func getAllPids() (pids []int, harderror error, softerrors []error) {
 }
 
 func openFromPid(pid int) (p Process, harderror error, softerrors []error) {
-	// Check if we have premissions to read the process memory
+	// Check if we have permissions to read the process memory
 	memPath := common.MemFilePathFromPid(uint(pid))
 	memFile, err := os.Open(memPath)
 	if err != nil {
@@ -91,5 +95,5 @@ func openFromPid(pid int) (p Process, harderror error, softerrors []error) {
 	}
 	defer memFile.Close()
 
-	return LinuxProcess(pid), nil, nil
+	return linuxProcess(pid), nil, nil
 }

--- a/process/process_windows.go
+++ b/process/process_windows.go
@@ -55,22 +55,26 @@ func getAllPids() (pids []int, harderror error, softerrors []error) {
 	return pids, nil, nil
 }
 
-type LinuxProcess int
+type windowsProcess int
 
-func (p LinuxProcess) Pid() int {
+func getProcess(pid int) windowsProcess {
+	return windowsProcess(pid)
+}
+
+func (p windowsProcess) Pid() int {
 	return int(p)
 }
 
-func (p LinuxProcess) Name() (name string, harderror error, softerrors []error) {
+func (p windowsProcess) Name() (name string, harderror error, softerrors []error) {
 	name, err := ProcessExe(p.Pid())
 	return name, err, nil
 }
 
-func (p LinuxProcess) Close() (harderror error, softerrors []error) {
+func (p windowsProcess) Close() (harderror error, softerrors []error) {
 	return nil, nil
 }
 
-func (p LinuxProcess) Handle() uintptr {
+func (p windowsProcess) Handle() uintptr {
 	// https://gist.github.com/castaneai/ed8cc2aaedf9d1eafd68
 	kernel32 := syscall.MustLoadDLL("kernel32.dll")
 	proc := kernel32.MustFindProc("OpenProcess")


### PR DESCRIPTION
Interfaces are used in the external interface in place of Linux-specific types, allowing Windows and any future supported platforms to use more appropriate structs to describe processes.